### PR TITLE
Modificar color del texto del contador a blue

### DIFF
--- a/lib/views/basic_screen.dart
+++ b/lib/views/basic_screen.dart
@@ -45,7 +45,10 @@ class _PantallaPrincipalState extends State<PantallaPrincipal> {
             ),
             Text(
               'Veces presionado: $_contador',
-              style: TextStyle(fontSize: 20),
+              style: TextStyle(
+                    fontSize: 20,
+                    color: Colors.blue,
+              ),
             ),
             SizedBox(height: 30),
             ElevatedButton(


### PR DESCRIPTION
**¿Por qué usamos setState aquí?**
Notifica a Flutter que el estado interno del widget (_contador) cambió y que la interfaz debe redibujarse para reflejar el nuevo valor.
**¿Qué pasa si no lo usamos?**
Si no se usa setState, el valor de contador se incrementaría en memoria pero ese cambio no se vería reflejado en la interfaz. 